### PR TITLE
Fix leetcode link in 01_foundations.md

### DIFF
--- a/content/06_algorithm_interview/01_foundations.md
+++ b/content/06_algorithm_interview/01_foundations.md
@@ -93,5 +93,5 @@ By going through lots of problems in different areas you will be ready to take o
     * Wildcard Matching
     * Minimum Window Substring
 
-[leetcode]: www.leetcode.com
+[leetcode]: http://www.leetcode.com
 

--- a/web_content/06_algorithm_interview/01_foundations.md
+++ b/web_content/06_algorithm_interview/01_foundations.md
@@ -96,5 +96,5 @@ By going through lots of problems in different areas you will be ready to take o
     * Wildcard Matching
     * Minimum Window Substring
 
-[leetcode]: www.leetcode.com
+[leetcode]: http://www.leetcode.com
 


### PR DESCRIPTION
Currently github pages [1] treats this link as a relative link and forwards viewer to https://course.jobsearch.dev/06_algorithm_interview/www.leetcode.com. Using absolute path should fix the issue.

[1] https://github.blog/2016-12-05-relative-links-for-github-pages/